### PR TITLE
Added an AttributeFilter

### DIFF
--- a/src/main/java/de/numcodex/sq2cql/Container.java
+++ b/src/main/java/de/numcodex/sq2cql/Container.java
@@ -21,13 +21,12 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Alexander Kiel
  */
+@SuppressWarnings("ClassCanBeRecord")
 public final class Container<T> {
 
+    private static final Container<?> EMPTY = new Container<>(null, Set.of());
     public static final BinaryOperator<Container<BooleanExpression>> AND = combiner(AndExpression::of);
     public static final BinaryOperator<Container<BooleanExpression>> OR = combiner(OrExpression::of);
-
-    private static final Container<?> EMPTY = new Container<>(null, Set.of());
-
     private final T expression;
     private final Set<CodeSystemDefinition> codeSystemDefinitions;
 

--- a/src/main/java/de/numcodex/sq2cql/PrintContext.java
+++ b/src/main/java/de/numcodex/sq2cql/PrintContext.java
@@ -1,19 +1,13 @@
 package de.numcodex.sq2cql;
 
+import de.numcodex.sq2cql.model.cql.Expression;
+
 /**
  * @author Alexander Kiel
  */
-public final class PrintContext {
+public record PrintContext(int indent, int precedence) {
 
     public static final PrintContext ZERO = new PrintContext(0, 0);
-
-    private final int indent;
-    private final int precedence;
-
-    private PrintContext(int indent, int precedence) {
-        this.indent = indent;
-        this.precedence = precedence;
-    }
 
     public String getIndent() {
         return " ".repeat(indent);
@@ -33,5 +27,13 @@ public final class PrintContext {
 
     public PrintContext resetPrecedence() {
         return new PrintContext(indent, 0);
+    }
+
+    public String print(Expression expression) {
+        return expression.print(this);
+    }
+
+    public String print(Container<? extends Expression> container) {
+        return container.getExpression().map(this::print).orElse("");
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/AttributeMapping.java
+++ b/src/main/java/de/numcodex/sq2cql/model/AttributeMapping.java
@@ -1,0 +1,28 @@
+package de.numcodex.sq2cql.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.numcodex.sq2cql.model.common.TermCode;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @author Lorenz Rosenau
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AttributeMapping(String type, TermCode key, String path) {
+
+    public AttributeMapping {
+        requireNonNull(type);
+        requireNonNull(key);
+        requireNonNull(path);
+    }
+
+    @JsonCreator
+    public static AttributeMapping of(@JsonProperty("attributeType") String type,
+                                      @JsonProperty("attributeKey") TermCode key,
+                                      @JsonProperty("attributeFhirPath") String path) {
+        return new AttributeMapping(type, key, path);
+    }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/Mapping.java
+++ b/src/main/java/de/numcodex/sq2cql/model/Mapping.java
@@ -7,7 +7,9 @@ import de.numcodex.sq2cql.model.common.TermCode;
 import de.numcodex.sq2cql.model.structured_query.Modifier;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -15,29 +17,34 @@ import static java.util.Objects.requireNonNull;
  * @author Alexander Kiel
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Mapping(TermCode key, String resourceType, String valueFhirPath, List<Modifier> fixedCriteria) {
+public record Mapping(TermCode key, String resourceType, String valueFhirPath, List<Modifier> fixedCriteria,
+                      Map<TermCode, AttributeMapping> attributeMappings) {
 
     public Mapping {
         requireNonNull(key);
         requireNonNull(resourceType);
         requireNonNull(valueFhirPath);
-        requireNonNull(fixedCriteria);
+        List.copyOf(fixedCriteria);
+        Map.copyOf(attributeMappings);
     }
 
     public static Mapping of(TermCode key, String resourceType) {
-        return new Mapping(requireNonNull(key), requireNonNull(resourceType), "value", List.of());
+        return new Mapping(key, resourceType, "value", List.of(), Map.of());
+    }
+
+    public static Mapping of(TermCode concept, String resourceType, String valueFhirPath) {
+        return new Mapping(concept, resourceType, valueFhirPath, List.of(), Map.of());
     }
 
     @JsonCreator
     public static Mapping of(@JsonProperty("key") TermCode key,
                              @JsonProperty("fhirResourceType") String resourceType,
                              @JsonProperty("valueFhirPath") String valueFhirPath,
-                             @JsonProperty("fixedCriteria") Modifier... fixedCriteria) {
+                             @JsonProperty("fixedCriteria") List<Modifier> fixedCriteria,
+                             @JsonProperty("attributeMappings") List<AttributeMapping> attributeMappings) {
         return new Mapping(key, resourceType, valueFhirPath == null ? "value" : valueFhirPath,
-                fixedCriteria == null ? List.of() : List.of(fixedCriteria));
-    }
-
-    public Optional<String> getValueFhirPath() {
-        return Optional.ofNullable(valueFhirPath);
+                fixedCriteria == null ? List.of() : List.copyOf(fixedCriteria),
+                attributeMappings == null ? Map.of() : attributeMappings.stream()
+                        .collect(Collectors.toMap(AttributeMapping::key, Function.identity())));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/AndExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/AndExpression.java
@@ -31,7 +31,7 @@ public record AndExpression(List<BooleanExpression> expressions) implements Bool
     @Override
     public String print(PrintContext printContext) {
         return printContext.parenthesize(PRECEDENCE, expressions.stream()
-                .map(e -> e.print(printContext.withPrecedence(PRECEDENCE)))
+                .map(printContext.withPrecedence(PRECEDENCE)::print)
                 .collect(joining(" and\n" + printContext.getIndent())));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/CodeSelector.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/CodeSelector.java
@@ -2,11 +2,9 @@ package de.numcodex.sq2cql.model.cql;
 
 import de.numcodex.sq2cql.PrintContext;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
 
-public record CodeSelector (String code, String codeSystemIdentifier) implements TermExpression {
+public record CodeSelector(String code, String codeSystemIdentifier) implements TermExpression {
 
     public CodeSelector {
         requireNonNull(code);

--- a/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
@@ -2,7 +2,6 @@ package de.numcodex.sq2cql.model.cql;
 
 import de.numcodex.sq2cql.PrintContext;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/de/numcodex/sq2cql/model/cql/ListSelector.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/ListSelector.java
@@ -4,22 +4,20 @@ import de.numcodex.sq2cql.PrintContext;
 
 import java.util.List;
 
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
-public record ListSelector(List<Expression> items) implements TermExpression {
+public record ListSelector(List<? extends Expression> items) implements TermExpression {
 
     public ListSelector {
         items = List.copyOf(items);
     }
 
-    public static ListSelector of(List<Expression> items) {
+    public static ListSelector of(List<? extends Expression> items) {
         return new ListSelector(items);
     }
 
     @Override
     public String print(PrintContext printContext) {
-        return "{ %s }".formatted(items.stream().map(e -> e.print(printContext))
-                .collect(joining(", ")));
+        return "{ %s }".formatted(items.stream().map(printContext::print).collect(joining(", ")));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/OrExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/OrExpression.java
@@ -31,7 +31,7 @@ public record OrExpression(List<BooleanExpression> expressions) implements Boole
     @Override
     public String print(PrintContext printContext) {
         return printContext.parenthesize(PRECEDENCE, expressions.stream()
-                .map(e -> e.print(printContext.withPrecedence(PRECEDENCE)))
+                .map(printContext.withPrecedence(PRECEDENCE)::print)
                 .collect(joining(" or\n" + printContext.getIndent())));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
@@ -15,12 +15,12 @@ public record RetrieveExpression(String resourceType, Expression terminology) im
         return new RetrieveExpression(resourceType, terminology);
     }
 
-    public String getResourceType() {
-        return resourceType;
-    }
-
     @Override
     public String print(PrintContext printContext) {
         return "[%s: %s]".formatted(resourceType, terminology.print(printContext));
+    }
+
+    public AliasExpression alias() {
+        return AliasExpression.of(resourceType.substring(0, 1));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/AbstractCriterion.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/AbstractCriterion.java
@@ -1,37 +1,46 @@
 package de.numcodex.sq2cql.model.structured_query;
 
 import de.numcodex.sq2cql.Container;
+import de.numcodex.sq2cql.model.AttributeMapping;
 import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.common.TermCode;
 import de.numcodex.sq2cql.model.cql.AliasExpression;
 import de.numcodex.sq2cql.model.cql.BooleanExpression;
 import de.numcodex.sq2cql.model.cql.CodeSelector;
 import de.numcodex.sq2cql.model.cql.CodeSystemDefinition;
+import de.numcodex.sq2cql.model.cql.ExistsExpression;
+import de.numcodex.sq2cql.model.cql.QueryExpression;
 import de.numcodex.sq2cql.model.cql.RetrieveExpression;
+import de.numcodex.sq2cql.model.cql.SourceClause;
+import de.numcodex.sq2cql.model.cql.WhereClause;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Abstract criterion holding the concept, every non-static criterion has.
  */
-public abstract class AbstractCriterion implements Criterion {
+abstract class AbstractCriterion implements Criterion {
 
     final Concept concept;
-    final List<Modifier> modifiers;
+    final List<AttributeFilter> attributeFilters;
 
-    AbstractCriterion(Concept concept, List<Modifier> modifiers) {
+    AbstractCriterion(Concept concept, List<AttributeFilter> attributeFilters) {
         this.concept = requireNonNull(concept);
-        this.modifiers = requireNonNull(modifiers);
+        this.attributeFilters = List.copyOf(attributeFilters);
     }
 
     /**
      * Returns the code selector expression according to the given term code.
      *
-     * @param mappingContext the mapping context to determine the code system definition of the concept
+     * @param mappingContext the mapping context to determine the code system definition of the
+     *                       concept
      * @param termCode       the term code to use
-     * @return a {@link Container} of the code selector expression together with its used {@link CodeSystemDefinition}
+     * @return a {@link Container} of the code selector expression together with its used {@link
+     * CodeSystemDefinition}
      */
     static Container<CodeSelector> codeSelector(MappingContext mappingContext, TermCode termCode) {
         var codeSystemDefinition = mappingContext.findCodeSystemDefinition(termCode.system())
@@ -43,15 +52,17 @@ public abstract class AbstractCriterion implements Criterion {
     /**
      * Returns the retrieve expression according to the given term code.
      * <p>
-     * Uses the mapping context to determine the resource type of the retrieve expression and the code system definition
-     * of the concept.
+     * Uses the mapping context to determine the resource type of the retrieve expression and the code
+     * system definition of the concept.
      *
      * @param mappingContext the mapping context
      * @param termCode       the term code to use
-     * @return a {@link Container} of the retrieve expression together with its used {@link CodeSystemDefinition}
+     * @return a {@link Container} of the retrieve expression together with its used {@link
+     * CodeSystemDefinition}
      * @throws TranslationException if the {@link RetrieveExpression} can't be build
      */
-    static Container<RetrieveExpression> retrieveExpr(MappingContext mappingContext, TermCode termCode) {
+    static Container<RetrieveExpression> retrieveExpr(MappingContext mappingContext,
+                                                      TermCode termCode) {
         return codeSelector(mappingContext, termCode).map(terminology -> {
             var mapping = mappingContext.findMapping(termCode)
                     .orElseThrow(() -> new MappingNotFoundException(termCode));
@@ -66,7 +77,20 @@ public abstract class AbstractCriterion implements Criterion {
                 .reduce(Container.empty(), Container.AND);
     }
 
+    static ExistsExpression existsExpr(SourceClause sourceClause, BooleanExpression whereExpr) {
+        return ExistsExpression.of(QueryExpression.of(sourceClause, WhereClause.of(whereExpr)));
+    }
+
     public Concept getConcept() {
         return concept;
+    }
+
+    protected List<Modifier> resolveAttributeModifiers(Map<TermCode, AttributeMapping> attributeMappings) {
+        return attributeFilters.stream().map(attributeFilter -> {
+            var key = attributeFilter.attributeCode();
+            var mapping = Optional.ofNullable(attributeMappings.get(key)).orElseThrow(() ->
+                    new MappingNotFoundException(key));
+            return attributeFilter.toModifier(mapping);
+        }).toList();
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/AttributeFilter.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/AttributeFilter.java
@@ -1,0 +1,51 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.numcodex.sq2cql.model.AttributeMapping;
+import de.numcodex.sq2cql.model.common.Comparator;
+import de.numcodex.sq2cql.model.common.TermCode;
+
+import java.util.stream.StreamSupport;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface AttributeFilter {
+
+    static AttributeFilter fromJsonNode(JsonNode attributeFilter) {
+        var attributeCode = TermCode.fromJsonNode(attributeFilter.get("attributeCode"));
+        var type = attributeFilter.get("type").asText();
+        if ("quantity-comparator".equals(type)) {
+            var comparator = Comparator.fromJson(attributeFilter.get("comparator").asText());
+            var value = attributeFilter.get("value").decimalValue();
+            var unit = attributeFilter.get("unit");
+            if (unit == null) {
+                return NumericAttributeFilter.of(attributeCode, comparator, value);
+            } else {
+                return NumericAttributeFilter.of(attributeCode, comparator, value, unit.get("code").asText());
+            }
+        }
+        if ("quantity-range".equals(type)) {
+            var lowerBound = attributeFilter.get("minValue").decimalValue();
+            var upperBound = attributeFilter.get("maxValue").decimalValue();
+            var unit = attributeFilter.get("unit");
+            if (unit == null) {
+                return RangeAttributeFilter.of(attributeCode, lowerBound, upperBound);
+            } else {
+                return RangeAttributeFilter.of(attributeCode, lowerBound, upperBound, unit.get("code").asText());
+            }
+        }
+        if ("concept".equals(type)) {
+            var selectedConcepts = attributeFilter.get("selectedConcepts");
+            if (selectedConcepts == null) {
+                throw new IllegalArgumentException("Missing `selectedConcepts` key in concept criterion.");
+            }
+            return ValueSetAttributeFilter.of(attributeCode, StreamSupport.stream(selectedConcepts.spliterator(), false)
+                    .map(TermCode::fromJsonNode).toArray(TermCode[]::new));
+        }
+        throw new IllegalArgumentException("unknown valueFilter type: " + type);
+    }
+
+    TermCode attributeCode();
+
+    Modifier toModifier(AttributeMapping attributeMapping);
+}

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/CodeModifier.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/CodeModifier.java
@@ -3,6 +3,7 @@ package de.numcodex.sq2cql.model.structured_query;
 import de.numcodex.sq2cql.Container;
 import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.cql.BooleanExpression;
+import de.numcodex.sq2cql.model.cql.ComparatorExpression;
 import de.numcodex.sq2cql.model.cql.Expression;
 import de.numcodex.sq2cql.model.cql.InvocationExpression;
 import de.numcodex.sq2cql.model.cql.ListSelector;
@@ -11,7 +12,8 @@ import de.numcodex.sq2cql.model.cql.StringLiteralExpression;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+
+import static de.numcodex.sq2cql.model.common.Comparator.EQUAL;
 
 /**
  * @author Alexander Kiel
@@ -31,8 +33,12 @@ public final class CodeModifier extends AbstractModifier {
 
     public Container<BooleanExpression> expression(MappingContext mappingContext, Expression alias) {
         var propertyExpr = InvocationExpression.of(alias, path);
-        var list = ListSelector.of(codes.stream().map(StringLiteralExpression::of).collect(Collectors.toList()));
-        return Container.of(MembershipExpression.in(propertyExpr, list));
+        if (codes.size() == 1) {
+            return Container.of(ComparatorExpression.of(propertyExpr, EQUAL, StringLiteralExpression.of(codes.get(0))));
+        } else {
+            var list = ListSelector.of(codes.stream().map(StringLiteralExpression::of).toList());
+            return Container.of(MembershipExpression.in(propertyExpr, list));
+        }
     }
 
     @Override

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/NumericAttributeFilter.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/NumericAttributeFilter.java
@@ -1,0 +1,51 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.model.AttributeMapping;
+import de.numcodex.sq2cql.model.common.Comparator;
+import de.numcodex.sq2cql.model.common.TermCode;
+
+import java.math.BigDecimal;
+
+import static java.util.Objects.requireNonNull;
+
+public record NumericAttributeFilter(TermCode attributeCode,
+                                     Comparator comparator,
+                                     BigDecimal value,
+                                     String unit) implements AttributeFilter {
+
+    public NumericAttributeFilter {
+        requireNonNull(attributeCode);
+        requireNonNull(comparator);
+        requireNonNull(value);
+    }
+
+    /**
+     * Returns a {@code NumericAttributeFilter}.
+     *
+     * @param attributeCode the code identifying the attribute
+     * @param comparator    the comparator that should be used in the value comparison
+     * @param value         the value that should be used in the value comparison
+     * @return the {@code NumericAttributeFilter}
+     */
+    public static NumericAttributeFilter of(TermCode attributeCode, Comparator comparator, BigDecimal value) {
+        return new NumericAttributeFilter(attributeCode, comparator, value, null);
+    }
+
+    /**
+     * Returns a {@code NumericAttributeFilter}.
+     *
+     * @param attributeCode the code identifying the attribute
+     * @param comparator    the comparator that should be used in the value comparison
+     * @param value         the value that should be used in the value comparison
+     * @param unit          the unit of the value
+     * @return the {@code NumericAttributeFilter}
+     */
+    public static NumericAttributeFilter of(TermCode attributeCode, Comparator comparator, BigDecimal value, String unit) {
+        return new NumericAttributeFilter(attributeCode, comparator, value, requireNonNull(unit));
+    }
+
+    @Override
+    public Modifier toModifier(AttributeMapping attributeMapping) {
+        return NumericModifier.of(attributeMapping.path(), comparator, value, unit);
+    }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/NumericModifier.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/NumericModifier.java
@@ -1,0 +1,56 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.Container;
+import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.common.Comparator;
+import de.numcodex.sq2cql.model.cql.BooleanExpression;
+import de.numcodex.sq2cql.model.cql.ComparatorExpression;
+import de.numcodex.sq2cql.model.cql.Expression;
+import de.numcodex.sq2cql.model.cql.InvocationExpression;
+import de.numcodex.sq2cql.model.cql.QuantityExpression;
+import de.numcodex.sq2cql.model.cql.TypeExpression;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class NumericModifier extends AbstractModifier {
+
+    private final Comparator comparator;
+    private final BigDecimal value;
+    private final String unit;
+
+    private NumericModifier(String path, Comparator comparator, BigDecimal value, String unit) {
+        super(path);
+        this.comparator = comparator;
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public static NumericModifier of(String path, Comparator comparator, BigDecimal value, String unit) {
+        return new NumericModifier(path, comparator, value, unit);
+    }
+
+    @Override
+    public Container<BooleanExpression> expression(MappingContext mappingContext, Expression alias) {
+        var castExpr = TypeExpression.of(InvocationExpression.of(alias, path), "Quantity");
+        return Container.of(ComparatorExpression.of(castExpr, comparator, quantityExpression(value, unit)));
+    }
+
+    private Expression quantityExpression(BigDecimal value, String unit) {
+        return unit == null ? QuantityExpression.of(value) : QuantityExpression.of(value, unit);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NumericModifier that = (NumericModifier) o;
+        return path.equals(that.path) && comparator.equals(that.comparator)
+                && value.equals(that.value) && unit.equals(that.unit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, comparator, value, unit);
+    }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/RangeAttributeFilter.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/RangeAttributeFilter.java
@@ -1,0 +1,33 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.model.AttributeMapping;
+import de.numcodex.sq2cql.model.common.TermCode;
+
+import java.math.BigDecimal;
+
+import static java.util.Objects.requireNonNull;
+
+public record RangeAttributeFilter(TermCode attributeCode,
+                                   BigDecimal lowerBound,
+                                   BigDecimal upperBound,
+                                   String unit) implements AttributeFilter {
+
+    public RangeAttributeFilter {
+        requireNonNull(attributeCode);
+        requireNonNull(lowerBound);
+        requireNonNull(upperBound);
+    }
+
+    public static RangeAttributeFilter of(TermCode attributeCode, BigDecimal lowerBound, BigDecimal upperBound) {
+        return new RangeAttributeFilter(attributeCode, lowerBound, upperBound, null);
+    }
+
+    public static RangeAttributeFilter of(TermCode attributeCode, BigDecimal lowerBound, BigDecimal upperBound, String unit) {
+        return new RangeAttributeFilter(attributeCode, lowerBound, upperBound, requireNonNull(unit));
+    }
+
+    @Override
+    public Modifier toModifier(AttributeMapping attributeMapping) {
+        return RangeModifier.of(attributeMapping.path(), lowerBound, upperBound, unit);
+    }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/RangeCriterion.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/RangeCriterion.java
@@ -1,19 +1,16 @@
 package de.numcodex.sq2cql.model.structured_query;
 
 import de.numcodex.sq2cql.Container;
+import de.numcodex.sq2cql.Lists;
 import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.common.TermCode;
-import de.numcodex.sq2cql.model.cql.AliasExpression;
 import de.numcodex.sq2cql.model.cql.BetweenExpression;
 import de.numcodex.sq2cql.model.cql.BooleanExpression;
-import de.numcodex.sq2cql.model.cql.ExistsExpression;
 import de.numcodex.sq2cql.model.cql.Expression;
 import de.numcodex.sq2cql.model.cql.InvocationExpression;
 import de.numcodex.sq2cql.model.cql.QuantityExpression;
-import de.numcodex.sq2cql.model.cql.QueryExpression;
 import de.numcodex.sq2cql.model.cql.SourceClause;
 import de.numcodex.sq2cql.model.cql.TypeExpression;
-import de.numcodex.sq2cql.model.cql.WhereClause;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -33,19 +30,22 @@ public final class RangeCriterion extends AbstractCriterion {
     private final BigDecimal upperBound;
     private final String unit;
 
-    private RangeCriterion(Concept concept, BigDecimal lowerBound, BigDecimal upperBound, String unit) {
-        super(concept, List.of());
-        this.lowerBound = requireNonNull(lowerBound);
-        this.upperBound = requireNonNull(upperBound);
+    private RangeCriterion(Concept concept, List<AttributeFilter> attributeFilters, BigDecimal lowerBound,
+                           BigDecimal upperBound, String unit) {
+        super(concept, attributeFilters);
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
         this.unit = unit;
     }
 
     public static RangeCriterion of(Concept concept, BigDecimal lowerBound, BigDecimal upperBound) {
-        return new RangeCriterion(concept, lowerBound, upperBound, null);
+        return new RangeCriterion(concept, List.of(), requireNonNull(lowerBound), requireNonNull(upperBound), null);
     }
 
-    public static RangeCriterion of(Concept concept, BigDecimal lowerBound, BigDecimal upperBound, String unit) {
-        return new RangeCriterion(concept, lowerBound, upperBound, requireNonNull(unit));
+    public static RangeCriterion of(Concept concept, BigDecimal lowerBound, BigDecimal upperBound, String unit,
+                                    AttributeFilter... attributeFilters) {
+        return new RangeCriterion(concept, List.of(attributeFilters), requireNonNull(lowerBound),
+                requireNonNull(upperBound), requireNonNull(unit));
     }
 
     public BigDecimal getLowerBound() {
@@ -79,15 +79,21 @@ public final class RangeCriterion extends AbstractCriterion {
     }
 
     private Container<BooleanExpression> expr(MappingContext mappingContext, TermCode termCode) {
-        return retrieveExpr(mappingContext, termCode).map(retrieveExpr -> {
-            var alias = AliasExpression.of(retrieveExpr.getResourceType().substring(0, 1));
+        return retrieveExpr(mappingContext, termCode).flatMap(retrieveExpr -> {
+            var alias = retrieveExpr.alias();
             var sourceClause = SourceClause.of(retrieveExpr, alias);
             var mapping = mappingContext.findMapping(termCode).orElseThrow(() -> new MappingNotFoundException(termCode));
             var castExpr = TypeExpression.of(InvocationExpression.of(alias, mapping.valueFhirPath()), "Quantity");
-            var whereExpression = BetweenExpression.of(castExpr, quantityExpression(lowerBound, unit),
+            var valueExpr = BetweenExpression.of(castExpr, quantityExpression(lowerBound, unit),
                     quantityExpression(upperBound, unit));
-            var queryExpr = QueryExpression.of(sourceClause, WhereClause.of(whereExpression));
-            return ExistsExpression.of(queryExpr);
+            var modifiers = Lists.concat(mapping.fixedCriteria(), resolveAttributeModifiers(mapping.attributeMappings()));
+            if (modifiers.isEmpty()) {
+                return Container.of(existsExpr(sourceClause, valueExpr));
+            } else {
+                var modifiersExpr = modifiersExpr(modifiers, mappingContext, alias);
+                return Container.AND.apply(Container.of(valueExpr), modifiersExpr)
+                        .map(expr -> existsExpr(sourceClause, expr));
+            }
         });
     }
 

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/RangeModifier.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/RangeModifier.java
@@ -1,0 +1,41 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.Container;
+import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.cql.BetweenExpression;
+import de.numcodex.sq2cql.model.cql.BooleanExpression;
+import de.numcodex.sq2cql.model.cql.Expression;
+import de.numcodex.sq2cql.model.cql.InvocationExpression;
+import de.numcodex.sq2cql.model.cql.QuantityExpression;
+import de.numcodex.sq2cql.model.cql.TypeExpression;
+
+import java.math.BigDecimal;
+
+public class RangeModifier extends AbstractModifier {
+
+    private final BigDecimal lowerBound;
+    private final BigDecimal upperBound;
+    private final String unit;
+
+    public RangeModifier(String path, BigDecimal lowerBound, BigDecimal upperBound, String unit) {
+        super(path);
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.unit = unit;
+    }
+
+    public static RangeModifier of(String path, BigDecimal lowerBound, BigDecimal upperBound, String unit) {
+        return new RangeModifier(path, lowerBound, upperBound, unit);
+    }
+
+    @Override
+    public Container<BooleanExpression> expression(MappingContext mappingContext, Expression alias) {
+        var castExpr = TypeExpression.of(InvocationExpression.of(alias, path), "Quantity");
+        return Container.of(BetweenExpression.of(castExpr, quantityExpression(lowerBound, unit),
+                quantityExpression(upperBound, unit)));
+    }
+
+    private Expression quantityExpression(BigDecimal value, String unit) {
+        return unit == null ? QuantityExpression.of(value) : QuantityExpression.of(value, unit);
+    }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/ValueSetAttributeFilter.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/ValueSetAttributeFilter.java
@@ -1,0 +1,40 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.model.AttributeMapping;
+import de.numcodex.sq2cql.model.common.TermCode;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record ValueSetAttributeFilter(TermCode attributeCode, List<TermCode> selectedConcepts)
+        implements AttributeFilter {
+
+    public ValueSetAttributeFilter {
+        requireNonNull(attributeCode);
+        requireNonNull(List.copyOf(selectedConcepts));
+    }
+
+    /**
+     * Returns a {@code ValueSetCriterion}.
+     *
+     * @param attributeCode    the code identifying the attribute
+     * @param selectedConcepts at least one selected value concept
+     * @return the {@code ValueSetCriterion}
+     */
+    public static ValueSetAttributeFilter of(TermCode attributeCode, TermCode... selectedConcepts) {
+        if (selectedConcepts == null || selectedConcepts.length == 0) {
+            throw new IllegalArgumentException("empty selected concepts");
+        }
+        return new ValueSetAttributeFilter(attributeCode, List.of(selectedConcepts));
+    }
+
+    @Override
+    public Modifier toModifier(AttributeMapping attributeMapping) {
+        return switch (attributeMapping.type()) {
+            case "code" -> CodeModifier.of(attributeMapping.path(), selectedConcepts.stream().map(TermCode::code).toArray(String[]::new));
+            case "coding" -> CodingModifier.of(attributeMapping.path(), selectedConcepts.toArray(TermCode[]::new));
+            default -> throw new IllegalStateException("unknown attribute mapping type: %s".formatted(attributeMapping.type()));
+        };
+    }
+}

--- a/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
@@ -1,8 +1,9 @@
 package de.numcodex.sq2cql;
 
-import de.numcodex.sq2cql.model.TermCodeNode;
+import de.numcodex.sq2cql.model.AttributeMapping;
 import de.numcodex.sq2cql.model.Mapping;
 import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.TermCodeNode;
 import de.numcodex.sq2cql.model.common.TermCode;
 import de.numcodex.sq2cql.model.cql.Library;
 import de.numcodex.sq2cql.model.structured_query.CodingModifier;
@@ -12,6 +13,7 @@ import de.numcodex.sq2cql.model.structured_query.Criterion;
 import de.numcodex.sq2cql.model.structured_query.NumericCriterion;
 import de.numcodex.sq2cql.model.structured_query.StructuredQuery;
 import de.numcodex.sq2cql.model.structured_query.TranslationException;
+import de.numcodex.sq2cql.model.structured_query.ValueSetAttributeFilter;
 import de.numcodex.sq2cql.model.structured_query.ValueSetCriterion;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -29,37 +31,37 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class TranslatorTest {
 
-    public static final TermCode ROOT = TermCode.of("", "", "");
-    public static final TermCode C71 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71",
+    static final TermCode ROOT = TermCode.of("", "", "");
+    static final TermCode C71 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71",
             "Malignant neoplasm of brain");
-    public static final TermCode C71_0 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.0", "");
-    public static final TermCode C71_1 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.1", "");
-    public static final TermCode PLATELETS = TermCode.of("http://loinc.org", "26515-7", "Platelets");
-    public static final TermCode FRAILTY_SCORE = TermCode.of("http://snomed.info/sct", "713636003",
+    static final TermCode C71_0 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.0", "");
+    static final TermCode C71_1 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.1", "");
+    static final TermCode PLATELETS = TermCode.of("http://loinc.org", "26515-7", "Platelets");
+    static final TermCode FRAILTY_SCORE = TermCode.of("http://snomed.info/sct", "713636003",
             "Canadian Study of Health and Aging Clinical Frailty Scale score");
-    public static final TermCode VERY_FIT = TermCode.of(
+    static final TermCode VERY_FIT = TermCode.of(
             "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score", "1", "Very Fit");
-    public static final TermCode WELL = TermCode.of(
+    static final TermCode WELL = TermCode.of(
             "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score", "2", "Well");
-    public static final TermCode COPD = TermCode.of("http://snomed.info/sct", "13645005",
+    static final TermCode COPD = TermCode.of("http://snomed.info/sct", "13645005",
             "Chronic obstructive lung disease (disorder)");
-    public static final TermCode G47_31 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "G47.31",
+    static final TermCode G47_31 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "G47.31",
             "Obstruktives Schlafapnoe-Syndrom");
-    public static final TermCode TOBACCO_SMOKING_STATUS = TermCode.of("http://loinc.org", "72166-2",
+    static final TermCode TOBACCO_SMOKING_STATUS = TermCode.of("http://loinc.org", "72166-2",
             "Tobacco smoking status");
-    public static final TermCode CURRENT_EVERY_DAY_SMOKER = TermCode.of("http://loinc.org", "LA18976-3",
+    static final TermCode CURRENT_EVERY_DAY_SMOKER = TermCode.of("http://loinc.org", "LA18976-3",
             "Current every day smoker");
-    public static final TermCode HYPERTENSION = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "I10",
+    static final TermCode HYPERTENSION = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "I10",
             "Essential (Primary) Hypertension");
-    public static final TermCode SERUM = TermCode.of("https://fhir.bbmri.de/CodeSystem/SampleMaterialType", "Serum",
+    static final TermCode SERUM = TermCode.of("https://fhir.bbmri.de/CodeSystem/SampleMaterialType", "Serum",
             "Serum");
-    public static final TermCode TMZ = TermCode.of("http://fhir.de/CodeSystem/dimdi/atc", "L01AX03",
+    static final TermCode TMZ = TermCode.of("http://fhir.de/CodeSystem/dimdi/atc", "L01AX03",
             "Temozolomide");
-    public static final TermCode LIPID = TermCode.of("http://fhir.de/CodeSystem/dimdi/atc", "C10AA",
+    static final TermCode LIPID = TermCode.of("http://fhir.de/CodeSystem/dimdi/atc", "C10AA",
             "lipid lowering drugs");
-    public static final TermCode CONFIRMED = TermCode.of("http://terminology.hl7.org/CodeSystem/condition-ver-status",
+    static final TermCode CONFIRMED = TermCode.of("http://terminology.hl7.org/CodeSystem/condition-ver-status",
             "confirmed", "Confirmed");
-    public static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
+    static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
             "http://fhir.de/CodeSystem/dimdi/icd-10-gm", "icd10",
             "http://loinc.org", "loinc",
             "https://fhir.bbmri.de/CodeSystem/SampleMaterialType", "sample",
@@ -68,6 +70,10 @@ class TranslatorTest {
             "http://hl7.org/fhir/administrative-gender", "gender",
             "http://terminology.hl7.org/CodeSystem/condition-ver-status", "ver_status",
             "https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score", "frailty-score");
+    static final TermCode VERIFICATION_STATUS = TermCode.of("hl7.org", "verificationStatus",
+            "verificationStatus");
+    static final AttributeMapping VERIFICATION_STATUS_ATTR_MAPPING =
+            AttributeMapping.of("coding", VERIFICATION_STATUS, "verificationStatus");
 
     @Test
     void toCQL_Inclusion_OneDisjunctionWithOneCriterion() {
@@ -214,14 +220,15 @@ class TranslatorTest {
     @Test
     void toCQL_Test_Task1() {
         var mappings = Map.of(PLATELETS, Mapping.of(PLATELETS, "Observation", "value"),
-                C71_0, Mapping.of(C71_0, "Condition"),
-                C71_1, Mapping.of(C71_1, "Condition"),
+                C71_0, Mapping.of(C71_0, "Condition", null, List.of(), List.of(VERIFICATION_STATUS_ATTR_MAPPING)),
+                C71_1, Mapping.of(C71_1, "Condition", null, List.of(), List.of(VERIFICATION_STATUS_ATTR_MAPPING)),
                 TMZ, Mapping.of(TMZ, "MedicationStatement"));
         var conceptTree = TermCodeNode.of(ROOT, TermCodeNode.of(TMZ), TermCodeNode.of(C71, TermCodeNode.of(C71_0),
                 TermCodeNode.of(C71_1)));
         var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
         var structuredQuery = StructuredQuery.of(List.of(
-                List.of(ConceptCriterion.of(Concept.of(C71), CodingModifier.of("verificationStatus", CONFIRMED))),
+                List.of(ConceptCriterion.of(Concept.of(C71),
+                        ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED))),
                 List.of(NumericCriterion.of(Concept.of(PLATELETS), LESS_THAN, BigDecimal.valueOf(50), "g/dl")),
                 List.of(ConceptCriterion.of(Concept.of(TMZ)))));
 
@@ -251,7 +258,8 @@ class TranslatorTest {
     @Test
     void toCQL_Test_Task2() {
         var mappings = Map.of(PLATELETS, Mapping.of(PLATELETS, "Observation", "value"),
-                HYPERTENSION, Mapping.of(HYPERTENSION, "Condition"),
+                HYPERTENSION, Mapping.of(HYPERTENSION, "Condition", null, List.of(),
+                        List.of(VERIFICATION_STATUS_ATTR_MAPPING)),
                 SERUM, Mapping.of(SERUM, "Specimen"),
                 LIPID, Mapping.of(LIPID, "MedicationStatement"));
         var conceptTree = TermCodeNode.of(ROOT, TermCodeNode.of(HYPERTENSION), TermCodeNode.of(SERUM),
@@ -260,7 +268,8 @@ class TranslatorTest {
                 conceptTree,
                 CODE_SYSTEM_ALIASES);
         var structuredQuery = StructuredQuery.of(List.of(
-                List.of(ConceptCriterion.of(Concept.of(HYPERTENSION), CodingModifier.of("verificationStatus", CONFIRMED))),
+                List.of(ConceptCriterion.of(Concept.of(HYPERTENSION),
+                        ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED))),
                 List.of(ConceptCriterion.of(Concept.of(SERUM)))), List.of(
                 List.of(ConceptCriterion.of(Concept.of(LIPID)))));
 
@@ -293,8 +302,10 @@ class TranslatorTest {
     @Test
     void toCQL_GeccoTask2() {
         var mappings = Map.of(FRAILTY_SCORE, Mapping.of(FRAILTY_SCORE, "Observation", "value"),
-                COPD, Mapping.of(COPD, "Condition", null, CodingModifier.of("verificationStatus", CONFIRMED)),
-                G47_31, Mapping.of(G47_31, "Condition", null, CodingModifier.of("verificationStatus", CONFIRMED)),
+                COPD, Mapping.of(COPD, "Condition", null, List.of(CodingModifier.of("verificationStatus", CONFIRMED)),
+                        List.of()),
+                G47_31, Mapping.of(G47_31, "Condition", null, List.of(CodingModifier.of("verificationStatus", CONFIRMED)),
+                        List.of()),
                 TOBACCO_SMOKING_STATUS, Mapping.of(TOBACCO_SMOKING_STATUS, "Observation", "value"));
         var conceptTree = TermCodeNode.of(ROOT, TermCodeNode.of(COPD), TermCodeNode.of(G47_31));
         var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);

--- a/src/test/java/de/numcodex/sq2cql/model/TermCodeNodeTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/TermCodeNodeTest.java
@@ -15,13 +15,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TermCodeNodeTest {
 
-    public static final TermCode ROOT = TermCode.of("foo", "root", "root");
-    public static final TermCode C1 = TermCode.of("foo", "c1", "c1");
-    public static final TermCode C2 = TermCode.of("foo", "c2", "c2");
-    public static final TermCode C11 = TermCode.of("foo", "c11", "c11");
-    public static final TermCode C12 = TermCode.of("foo", "c12", "c12");
-    public static final TermCode C111 = TermCode.of("foo", "c111", "c111");
-    public static final TermCode C112 = TermCode.of("foo", "c112", "c112");
+    static final TermCode ROOT = TermCode.of("foo", "root", "root");
+    static final TermCode C1 = TermCode.of("foo", "c1", "c1");
+    static final TermCode C2 = TermCode.of("foo", "c2", "c2");
+    static final TermCode C11 = TermCode.of("foo", "c11", "c11");
+    static final TermCode C12 = TermCode.of("foo", "c12", "c12");
+    static final TermCode C111 = TermCode.of("foo", "c111", "c111");
+    static final TermCode C112 = TermCode.of("foo", "c112", "c112");
 
     @Test
     void noChildren() {

--- a/src/test/java/de/numcodex/sq2cql/model/cql/AliasExpressionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/AliasExpressionTest.java
@@ -3,11 +3,12 @@ package de.numcodex.sq2cql.model.cql;
 import de.numcodex.sq2cql.PrintContext;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AliasExpressionTest {
 
-    private static final String IDENTIFIER = "identifier-190631";
+    static final String IDENTIFIER = "identifier-190631";
 
     @Test
     void constructor() {

--- a/src/test/java/de/numcodex/sq2cql/model/cql/CodeSelectorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/CodeSelectorTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CodeSelectorTest {
 
-    private static final String CODE = "code-191141";
-    private static final String SYSTEM = "system-191157";
+    static final String CODE = "code-191141";
+    static final String SYSTEM = "system-191157";
 
     @Test
     void print() {

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/CodeModifierTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/CodeModifierTest.java
@@ -1,0 +1,29 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.PrintContext;
+import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.cql.AliasExpression;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CodeModifierTest {
+
+    @Test
+    void expression_OneCode() {
+        var modifier = CodeModifier.of("status", "final");
+
+        var expression = modifier.expression(MappingContext.of(), AliasExpression.of("O"));
+
+        assertEquals("O.status = 'final'", PrintContext.ZERO.print(expression));
+    }
+
+    @Test
+    void expression_TwoCodes() {
+        var modifier = CodeModifier.of("status", "completed", "in-progress");
+
+        var expression = modifier.expression(MappingContext.of(), AliasExpression.of("P"));
+
+        assertEquals("P.status in { 'completed', 'in-progress' }", PrintContext.ZERO.print(expression));
+    }
+}

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/CodingModifierTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/CodingModifierTest.java
@@ -1,7 +1,6 @@
 package de.numcodex.sq2cql.model.structured_query;
 
 import de.numcodex.sq2cql.PrintContext;
-import de.numcodex.sq2cql.model.TermCodeNode;
 import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.common.TermCode;
 import de.numcodex.sq2cql.model.cql.AliasExpression;
@@ -16,13 +15,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class CodingModifierTest {
 
-    public static final TermCode CONFIRMED = TermCode.of("http://terminology.hl7.org/CodeSystem/condition-ver-status",
+    static final TermCode CONFIRMED = TermCode.of("http://terminology.hl7.org/CodeSystem/condition-ver-status",
             "confirmed", "Conformed");
 
-    public static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
+    static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
             "http://terminology.hl7.org/CodeSystem/condition-ver-status", "ver_status");
 
-    public static final MappingContext MAPPING_CONTEXT = MappingContext.of(Map.of(), null, CODE_SYSTEM_ALIASES);
+    static final MappingContext MAPPING_CONTEXT = MappingContext.of(Map.of(), null, CODE_SYSTEM_ALIASES);
 
     @Test
     void expression() {
@@ -31,6 +30,6 @@ class CodingModifierTest {
         var expression = modifier.expression(MAPPING_CONTEXT, AliasExpression.of("C"));
 
         assertEquals("C.verificationStatus.coding contains Code 'confirmed' from ver_status",
-                expression.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                expression.getExpression().map(PrintContext.ZERO::print).orElse(""));
     }
 }

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptCriterionTest.java
@@ -1,19 +1,22 @@
 package de.numcodex.sq2cql.model.structured_query;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.numcodex.sq2cql.Container;
 import de.numcodex.sq2cql.PrintContext;
+import de.numcodex.sq2cql.model.AttributeMapping;
 import de.numcodex.sq2cql.model.Mapping;
 import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.TermCodeNode;
 import de.numcodex.sq2cql.model.common.TermCode;
-import de.numcodex.sq2cql.model.cql.BooleanExpression;
 import de.numcodex.sq2cql.model.cql.CodeSystemDefinition;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static de.numcodex.sq2cql.model.common.Comparator.LESS_THAN;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -21,26 +24,36 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class ConceptCriterionTest {
 
-    public static final TermCode C71 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71",
+    static final TermCode C71 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71",
             "Malignant neoplasm of brain");
-    public static final TermCode C71_1 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.1",
+    static final TermCode C71_1 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.1",
             "Frontal lobe");
-    public static final TermCode C71_2 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.2",
+    static final TermCode C71_2 = TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "C71.2",
             "Temporal lobe");
-    public static final TermCode CONFIRMED = TermCode.of("http://terminology.hl7.org/CodeSystem/condition-ver-status",
+    static final TermCode BLOOD_PRESSURE = TermCode.of("http://loinc.org", "85354-9",
+            "Blood pressure panel with all children optional");
+    static final TermCode DIASTOLIC_BLOOD_PRESSURE = TermCode.of("http://loinc.org", "8462-4",
+            "Diastolic blood pressure");
+    static final TermCode CONFIRMED = TermCode.of("http://terminology.hl7.org/CodeSystem/condition-ver-status",
             "confirmed", "Confirmed");
-    public static final TermCode THERAPEUTIC_PROCEDURE = TermCode.of("http://snomed.info/sct",
+    static final TermCode THERAPEUTIC_PROCEDURE = TermCode.of("http://snomed.info/sct",
             "277132007", "Therapeutic procedure (procedure)");
-    public static final CodeSystemDefinition ICD10_CODE_SYSTEM_DEF = CodeSystemDefinition.of("icd10",
+    static final CodeSystemDefinition ICD10_CODE_SYSTEM_DEF = CodeSystemDefinition.of("icd10",
             "http://fhir.de/CodeSystem/dimdi/icd-10-gm");
-    public static final CodeSystemDefinition SNOMED_CODE_SYSTEM_DEF = CodeSystemDefinition.of("snomed",
+    static final CodeSystemDefinition SNOMED_CODE_SYSTEM_DEF = CodeSystemDefinition.of("snomed",
             "http://snomed.info/sct");
-    public static final CodeSystemDefinition VER_STATUS_CODE_SYSTEM_DEF = CodeSystemDefinition.of("ver_status",
+    static final CodeSystemDefinition VER_STATUS_CODE_SYSTEM_DEF = CodeSystemDefinition.of("ver_status",
             "http://terminology.hl7.org/CodeSystem/condition-ver-status");
-    public static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
+    static final TermCode VERIFICATION_STATUS = TermCode.of("hl7.org", "verificationStatus",
+            "verificationStatus");
+
+    static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
             "http://fhir.de/CodeSystem/dimdi/icd-10-gm", "icd10",
             "http://snomed.info/sct", "snomed",
+            "http://loinc.org", "loinc",
             "http://terminology.hl7.org/CodeSystem/condition-ver-status", "ver_status");
+
+    static final CodeSystemDefinition LOINC_CODE_SYSTEM_DEF = CodeSystemDefinition.of("loinc", "http://loinc.org");
 
     @Test
     void fromJson() throws Exception {
@@ -99,15 +112,84 @@ class ConceptCriterionTest {
     }
 
     @Test
+    void fromJson_BloodPressure() throws Exception {
+        var mapper = new ObjectMapper();
+
+        var criterion = (ConceptCriterion) mapper.readValue("""
+                {
+                  "termCodes": [{
+                    "system": "http://loinc.org",
+                    "code": "85354-9",
+                    "display": "Blood pressure panel with all children optional"
+                  }],
+                  "attributeFilters": [
+                    {
+                      "attributeCode": {
+                        "system": "http://loinc.org",
+                        "code": "8462-4",
+                        "display": "Diastolic blood pressure"
+                      },
+                      "type": "quantity-comparator",
+                      "comparator": "lt",
+                      "value": 80,
+                      "unit": {
+                        "code": "mm[Hg]"
+                      }
+                    }
+                  ]
+                }
+                """, Criterion.class);
+
+        assertEquals(Concept.of(BLOOD_PRESSURE), criterion.getConcept());
+        assertEquals(List.of(NumericAttributeFilter.of(DIASTOLIC_BLOOD_PRESSURE, LESS_THAN, BigDecimal.valueOf(80), "mm[Hg]")),
+                criterion.attributeFilters);
+    }
+
+    @Test
+    void fromJson_BloodPressureRange() throws Exception {
+        var mapper = new ObjectMapper();
+
+        var criterion = (ConceptCriterion) mapper.readValue("""
+                {
+                  "termCodes": [{
+                    "system": "http://loinc.org",
+                    "code": "85354-9",
+                    "display": "Blood pressure panel with all children optional"
+                  }],
+                  "attributeFilters": [
+                    {
+                      "attributeCode": {
+                        "system": "http://loinc.org",
+                        "code": "8462-4",
+                        "display": "Diastolic blood pressure"
+                      },
+                      "type": "quantity-range",
+                      "minValue": 60,
+                      "maxValue": 100,
+                      "unit": {
+                        "code": "mm[Hg]"
+                      }
+                    }
+                  ]
+                }
+                """, Criterion.class);
+
+        assertEquals(Concept.of(BLOOD_PRESSURE), criterion.getConcept());
+        assertEquals(List.of(RangeAttributeFilter.of(DIASTOLIC_BLOOD_PRESSURE, BigDecimal.valueOf(60),
+                        BigDecimal.valueOf(100), "mm[Hg]")),
+                criterion.attributeFilters);
+    }
+
+    @Test
     void toCql() {
         var criterion = ConceptCriterion.of(Concept.of(C71));
         var mappingContext = MappingContext.of(Map.of(C71, Mapping.of(C71, "Condition")), TermCodeNode.of(C71),
                 CODE_SYSTEM_ALIASES);
 
-        Container<BooleanExpression> container = criterion.toCql(mappingContext);
+        var container = criterion.toCql(mappingContext);
 
         assertEquals("exists [Condition: Code 'C71' from icd10]", container.getExpression()
-                .map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                .map(PrintContext.ZERO::print).orElse(""));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 
@@ -117,75 +199,104 @@ class ConceptCriterionTest {
         var mappings = Map.of(C71_1, Mapping.of(C71_1, "Condition"), C71_2, Mapping.of(C71_2, "Condition"));
         var mappingContext = MappingContext.of(mappings, TermCodeNode.of(C71), CODE_SYSTEM_ALIASES);
 
-        Container<BooleanExpression> container = criterion.toCql(mappingContext);
+        var container = criterion.toCql(mappingContext);
 
         assertEquals("""
                 exists [Condition: Code 'C71.1' from icd10] or
                 exists [Condition: Code 'C71.2' from icd10]""", container.getExpression()
-                .map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                .map(PrintContext.ZERO::print).orElse(""));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 
     @Test
-    void toCql_WithModifier() {
-        var criterion = ConceptCriterion.of(Concept.of(C71), CodingModifier.of("verificationStatus", CONFIRMED));
-        var mappingContext = MappingContext.of(Map.of(C71, Mapping.of(C71, "Condition")), TermCodeNode.of(C71),
-                CODE_SYSTEM_ALIASES);
+    void toCql_WithAttributeFilter() {
+        var criterion = ConceptCriterion.of(Concept.of(C71),
+                ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED));
+        var mapping = Mapping.of(C71, "Condition", null, List.of(),
+                List.of(AttributeMapping.of("coding", VERIFICATION_STATUS, "verificationStatus")));
+        var mappingContext = MappingContext.of(Map.of(C71, mapping), TermCodeNode.of(C71), CODE_SYSTEM_ALIASES);
 
-        Container<BooleanExpression> container = criterion.toCql(mappingContext);
-
-        assertEquals("""
-                        exists from [Condition: Code 'C71' from icd10] C
-                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
-        assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
-    }
-
-    @Test
-    void toCql_FixedCriteria_Code() {
-        var criterion = ConceptCriterion.of(Concept.of(THERAPEUTIC_PROCEDURE));
-        var mappingContext = MappingContext.of(Map.of(THERAPEUTIC_PROCEDURE, Mapping.of(THERAPEUTIC_PROCEDURE,
-                        "Procedure", null, CodeModifier.of("status", "completed", "in-progress"))),
-                TermCodeNode.of(THERAPEUTIC_PROCEDURE), CODE_SYSTEM_ALIASES);
-
-        Container<BooleanExpression> container = criterion.toCql(mappingContext);
-
-        assertEquals("""
-                        exists from [Procedure: Code '277132007' from snomed] P
-                          where P.status in { 'completed', 'in-progress' }""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
-        assertEquals(Set.of(SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
-    }
-
-    @Test
-    void toCql_FixedCriteria_Coding() {
-        var criterion = ConceptCriterion.of(Concept.of(C71));
-        var mappingContext = MappingContext.of(Map.of(C71, Mapping.of(C71, "Condition", null,
-                CodingModifier.of("verificationStatus", CONFIRMED))), TermCodeNode.of(C71), CODE_SYSTEM_ALIASES);
-
-        Container<BooleanExpression> container = criterion.toCql(mappingContext);
+        var container = criterion.toCql(mappingContext);
 
         assertEquals("""
                         exists from [Condition: Code 'C71' from icd10] C
                           where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                PrintContext.ZERO.print(container));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 
     @Test
-    void toCql_Expanded_WithModifier() {
-        var criterion = ConceptCriterion.of(Concept.of(C71), CodingModifier.of("verificationStatus", CONFIRMED));
-        var mappingContext = MappingContext.of(Map.of(C71_1, Mapping.of(C71_1, "Condition"), C71_2, Mapping.of(C71_2,
-                "Condition")), TermCodeNode.of(C71, TermCodeNode.of(C71_1), TermCodeNode.of(C71_2)), CODE_SYSTEM_ALIASES);
+    void toCql_Expanded_WithAttributeFilter() {
+        var criterion = ConceptCriterion.of(Concept.of(C71),
+                ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED));
+        var mapping1 = Mapping.of(C71_1, "Condition", null, List.of(),
+                List.of(AttributeMapping.of("coding", VERIFICATION_STATUS, "verificationStatus")));
+        var mapping2 = Mapping.of(C71_2, "Condition", null, List.of(),
+                List.of(AttributeMapping.of("coding", VERIFICATION_STATUS, "verificationStatus")));
+        var mappingContext = MappingContext.of(Map.of(C71_1, mapping1, C71_2, mapping2),
+                TermCodeNode.of(C71, TermCodeNode.of(C71_1), TermCodeNode.of(C71_2)), CODE_SYSTEM_ALIASES);
 
-        Container<BooleanExpression> container = criterion.toCql(mappingContext);
+        var container = criterion.toCql(mappingContext);
 
         assertEquals("""
                         exists from [Condition: Code 'C71.1' from icd10] C
                           where C.verificationStatus.coding contains Code 'confirmed' from ver_status or
                         exists from [Condition: Code 'C71.2' from icd10] C
                           where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                PrintContext.ZERO.print(container));
+        assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
+    }
+
+    @Test
+    void toCql_WithDiastolicBloodPressureAttributeFilter() {
+        var criterion = ConceptCriterion.of(Concept.of(BLOOD_PRESSURE),
+                NumericAttributeFilter.of(DIASTOLIC_BLOOD_PRESSURE, LESS_THAN, BigDecimal.valueOf(80), "mm[Hg]"));
+        var mappingContext = MappingContext.of(Map.of(
+                BLOOD_PRESSURE, Mapping.of(BLOOD_PRESSURE, "Observation", "value", List.of(),
+                        List.of(AttributeMapping.of("", DIASTOLIC_BLOOD_PRESSURE,
+                                format("component.where(code.coding.exists(system = '%s' and code = '%s')).value.first()",
+                                        DIASTOLIC_BLOOD_PRESSURE.system(), DIASTOLIC_BLOOD_PRESSURE.code()))))
+        ), null, CODE_SYSTEM_ALIASES);
+
+        var container = criterion.toCql(mappingContext);
+
+        assertEquals("""
+                        exists from [Observation: Code '85354-9' from loinc] O
+                          where O.component.where(code.coding.exists(system = 'http://loinc.org' and code = '8462-4')).value.first() as Quantity < 80 'mm[Hg]'""",
+                PrintContext.ZERO.print(container));
+        assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
+    }
+
+    @Test
+    void toCql_FixedCriteria_Code() {
+        var criterion = ConceptCriterion.of(Concept.of(THERAPEUTIC_PROCEDURE));
+        var mappingContext = MappingContext.of(Map.of(
+                THERAPEUTIC_PROCEDURE, Mapping.of(THERAPEUTIC_PROCEDURE, "Procedure", null,
+                        List.of(CodeModifier.of("status", "completed", "in-progress")), List.of())
+        ), null, CODE_SYSTEM_ALIASES);
+
+        var container = criterion.toCql(mappingContext);
+
+        assertEquals("""
+                        exists from [Procedure: Code '277132007' from snomed] P
+                          where P.status in { 'completed', 'in-progress' }""",
+                PrintContext.ZERO.print(container));
+        assertEquals(Set.of(SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
+    }
+
+    @Test
+    void toCql_FixedCriteria_Coding() {
+        var criterion = ConceptCriterion.of(Concept.of(C71));
+        var mappingContext = MappingContext.of(Map.of(
+                C71, Mapping.of(C71, "Condition", null, List.of(CodingModifier.of("verificationStatus", CONFIRMED)),
+                        List.of())), TermCodeNode.of(C71), CODE_SYSTEM_ALIASES);
+
+        var container = criterion.toCql(mappingContext);
+
+        assertEquals("""
+                        exists from [Condition: Code 'C71' from icd10] C
+                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
+                PrintContext.ZERO.print(container));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 }

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptTest.java
@@ -3,12 +3,13 @@ package de.numcodex.sq2cql.model.structured_query;
 import de.numcodex.sq2cql.model.common.TermCode;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConceptTest {
 
-    public static final TermCode C1 = TermCode.of("foo", "c1", "c1-d");
-    public static final TermCode C2 = TermCode.of("foo", "c2", "c2-d");
+    static final TermCode C1 = TermCode.of("foo", "c1", "c1-d");
+    static final TermCode C2 = TermCode.of("foo", "c2", "c2-d");
 
     @Test
     void constructor_Null() {

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/StructuredQueryTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/StructuredQueryTest.java
@@ -13,8 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class StructuredQueryTest {
 
-    public static final TermCode TC_1 = TermCode.of("tc", "1", "");
-    public static final TermCode TC_2 = TermCode.of("tc", "2", "");
+    static final TermCode TC_1 = TermCode.of("tc", "1", "");
+    static final TermCode TC_2 = TermCode.of("tc", "2", "");
 
     @Test
     void fromJson_NoInclusionCriteria() {

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ValueSetCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ValueSetCriterionTest.java
@@ -1,13 +1,11 @@
 package de.numcodex.sq2cql.model.structured_query;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.numcodex.sq2cql.Container;
 import de.numcodex.sq2cql.PrintContext;
-import de.numcodex.sq2cql.model.TermCodeNode;
+import de.numcodex.sq2cql.model.AttributeMapping;
 import de.numcodex.sq2cql.model.Mapping;
 import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.common.TermCode;
-import de.numcodex.sq2cql.model.cql.BooleanExpression;
 import de.numcodex.sq2cql.model.cql.CodeSystemDefinition;
 import org.junit.jupiter.api.Test;
 
@@ -23,35 +21,38 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class ValueSetCriterionTest {
 
-    public static final TermCode COVID = TermCode.of("http://loinc.org", "94500-6", "COVID");
-    public static final TermCode SEX = TermCode.of("http://loinc.org", "76689-9", "Sex assigned at birth");
-    public static final TermCode POSITIVE = TermCode.of("http://snomed.info/sct", "positive", "positive");
-    public static final TermCode MALE = TermCode.of("http://hl7.org/fhir/administrative-gender", "male", "Male");
-    public static final TermCode FEMALE = TermCode.of("http://hl7.org/fhir/administrative-gender", "female", "Female");
-    public static final TermCode FINDING = TermCode.of("http://snomed.info/sct", "404684003", "Clinical finding (finding)");
-    public static final TermCode SEVERE = TermCode.of("http://snomed.info/sct", "24484000", "Severe (severity modifier)");
-    public static final TermCode TNM_C = TermCode.of("http://loinc.org", "21908-9", "Stage group.clinical Cancer");
-    public static final TermCode TNM_P = TermCode.of("http://loinc.org", "21902-2", "Stage group.pathology Cancer");
-    public static final TermCode LA3649_6 = TermCode.of("http://loinc.org", "LA3649-6", "Stage IVB");
+    static final TermCode COVID = TermCode.of("http://loinc.org", "94500-6", "COVID");
+    static final TermCode SEX = TermCode.of("http://loinc.org", "76689-9", "Sex assigned at birth");
+    static final TermCode POSITIVE = TermCode.of("http://snomed.info/sct", "positive", "positive");
+    static final TermCode MALE = TermCode.of("http://hl7.org/fhir/administrative-gender", "male", "Male");
+    static final TermCode FEMALE = TermCode.of("http://hl7.org/fhir/administrative-gender", "female", "Female");
+    static final TermCode FINDING = TermCode.of("http://snomed.info/sct", "404684003", "Clinical finding (finding)");
+    static final TermCode SEVERE = TermCode.of("http://snomed.info/sct", "24484000", "Severe (severity modifier)");
+    static final TermCode TNM_C = TermCode.of("http://loinc.org", "21908-9", "Stage group.clinical Cancer");
+    static final TermCode TNM_P = TermCode.of("http://loinc.org", "21902-2", "Stage group.pathology Cancer");
+    static final TermCode LA3649_6 = TermCode.of("http://loinc.org", "LA3649-6", "Stage IVB");
+    static final TermCode STATUS = TermCode.of("http://hl7.org/fhir", "observation-status", "observation-status");
+    static final TermCode FINAL = TermCode.of("http://hl7.org/fhir/observation-status", "final", "final");
 
-    public static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
+    static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of(
             "http://loinc.org", "loinc",
             "http://snomed.info/sct", "snomed",
             "http://hl7.org/fhir/administrative-gender", "gender");
 
-    public static final MappingContext MAPPING_CONTEXT = MappingContext.of(Map.of(
-            COVID, Mapping.of(COVID, "Observation", "value"),
+    static final MappingContext MAPPING_CONTEXT = MappingContext.of(Map.of(
+            COVID, Mapping.of(COVID, "Observation", "value", List.of(),
+                    List.of(AttributeMapping.of("code", STATUS, "status"))),
             SEX, Mapping.of(SEX, "Observation", "value"),
             FINDING, Mapping.of(FINDING, "Condition", "severity"),
             TNM_C, Mapping.of(TNM_C, "Observation", "value"),
             TNM_P, Mapping.of(TNM_P, "Observation", "value")
     ), null, CODE_SYSTEM_ALIASES);
 
-    public static final CodeSystemDefinition LOINC_CODE_SYSTEM_DEF = CodeSystemDefinition.of("loinc",
+    static final CodeSystemDefinition LOINC_CODE_SYSTEM_DEF = CodeSystemDefinition.of("loinc",
             "http://loinc.org");
-    public static final CodeSystemDefinition SNOMED_CODE_SYSTEM_DEF = CodeSystemDefinition.of("snomed",
+    static final CodeSystemDefinition SNOMED_CODE_SYSTEM_DEF = CodeSystemDefinition.of("snomed",
             "http://snomed.info/sct");
-    public static final CodeSystemDefinition GENDER_CODE_SYSTEM_DEF = CodeSystemDefinition.of("gender",
+    static final CodeSystemDefinition GENDER_CODE_SYSTEM_DEF = CodeSystemDefinition.of("gender",
             "http://hl7.org/fhir/administrative-gender");
 
     @Test
@@ -88,6 +89,52 @@ class ValueSetCriterionTest {
     }
 
     @Test
+    void fromJson_WithAttributeFilter() throws Exception {
+        var mapper = new ObjectMapper();
+
+        var criterion = (ValueSetCriterion) mapper.readValue("""
+                {
+                  "termCodes": [{
+                    "system": "http://loinc.org",
+                    "code": "76689-9",
+                    "display": "Sex assigned at birth"
+                  }],
+                  "valueFilter": {
+                    "type": "concept",
+                    "selectedConcepts": [
+                      {
+                        "system": "http://hl7.org/fhir/administrative-gender",
+                        "code": "male",
+                        "display": "Male"
+                      }
+                    ]
+                  },
+                  "attributeFilters": [
+                    {
+                      "attributeCode": {
+                        "system": "http://hl7.org/fhir",
+                        "code": "observation-status",
+                        "display": "observation-status"
+                      },
+                      "type": "concept",
+                      "selectedConcepts": [
+                        {
+                          "system": "http://hl7.org/fhir/observation-status",
+                          "code": "final",
+                          "display": "final"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """, Criterion.class);
+
+        assertEquals(Concept.of(SEX), criterion.getConcept());
+        assertEquals(List.of(MALE), criterion.getSelectedConcepts());
+        assertEquals(List.of(ValueSetAttributeFilter.of(STATUS, FINAL)), criterion.attributeFilters);
+    }
+
+    @Test
     void toCql_WithNoConcept() {
         assertThrows(IllegalArgumentException.class, () -> ValueSetCriterion.of(Concept.of(COVID)));
     }
@@ -96,12 +143,12 @@ class ValueSetCriterionTest {
     void toCql_WithOneConcept() {
         var criterion = ValueSetCriterion.of(Concept.of(COVID), POSITIVE);
 
-        Container<BooleanExpression> container = criterion.toCql(MAPPING_CONTEXT);
+        var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
                         exists from [Observation: Code '94500-6' from loinc] O
                           where O.value.coding contains Code 'positive' from snomed""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 
@@ -109,14 +156,14 @@ class ValueSetCriterionTest {
     void toCql_WithOneConceptAndMultipleTermCodes() {
         var criterion = ValueSetCriterion.of(Concept.of(TNM_C, TNM_P), LA3649_6);
 
-        Container<BooleanExpression> container = criterion.toCql(MAPPING_CONTEXT);
+        var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
                         exists from [Observation: Code '21908-9' from loinc] O
                           where O.value.coding contains Code 'LA3649-6' from loinc or
                         exists from [Observation: Code '21902-2' from loinc] O
                           where O.value.coding contains Code 'LA3649-6' from loinc""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 
@@ -124,13 +171,13 @@ class ValueSetCriterionTest {
     void toCql_WithTwoConcepts() {
         var criterion = ValueSetCriterion.of(Concept.of(SEX), MALE, FEMALE);
 
-        Container<BooleanExpression> container = criterion.toCql(MAPPING_CONTEXT);
+        var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
                         exists from [Observation: Code '76689-9' from loinc] O
                           where O.value.coding contains Code 'male' from gender or
                             O.value.coding contains Code 'female' from gender""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, GENDER_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
 
@@ -138,12 +185,47 @@ class ValueSetCriterionTest {
     void toCql_WithConditionSeverity() {
         var criterion = ValueSetCriterion.of(Concept.of(FINDING), SEVERE);
 
-        Container<BooleanExpression> container = criterion.toCql(MAPPING_CONTEXT);
+        var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
                         exists from [Condition: Code '404684003' from snomed] C
                           where C.severity.coding contains Code '24484000' from snomed""",
-                container.getExpression().map(e -> e.print(PrintContext.ZERO)).orElse(""));
+                PrintContext.ZERO.print(container));
         assertEquals(Set.of(SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
+    }
+
+    @Test
+    void toCql_WithAttributeFilter() {
+        var criterion = ValueSetCriterion.of(Concept.of(COVID), List.of(POSITIVE),
+                ValueSetAttributeFilter.of(STATUS, FINAL));
+
+        var container = criterion.toCql(MAPPING_CONTEXT);
+
+        assertEquals("""
+                        exists from [Observation: Code '94500-6' from loinc] O
+                          where O.value.coding contains Code 'positive' from snomed and
+                            O.status = 'final'""",
+                PrintContext.ZERO.print(container));
+        assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, SNOMED_CODE_SYSTEM_DEF),
+                container.getCodeSystemDefinitions());
+    }
+
+    @Test
+    void toCql_WithFixedCriteria() {
+        var criterion = ValueSetCriterion.of(Concept.of(COVID), List.of(POSITIVE));
+        var mappingContext = MappingContext.of(Map.of(
+                COVID, Mapping.of(COVID, "Observation", "value", List.of(CodeModifier.of("status", "final")),
+                        List.of())
+        ), null, CODE_SYSTEM_ALIASES);
+
+        var container = criterion.toCql(mappingContext);
+
+        assertEquals("""
+                        exists from [Observation: Code '94500-6' from loinc] O
+                          where O.value.coding contains Code 'positive' from snomed and
+                            O.status = 'final'""",
+                PrintContext.ZERO.print(container));
+        assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, SNOMED_CODE_SYSTEM_DEF),
+                container.getCodeSystemDefinitions());
     }
 }


### PR DESCRIPTION
Added an AttributeFilter class that is subclassed by the different types of attributeFilter. Added an AttributeMapping as part of the Mapping. AttributeFilter are converted to CQL by first converting them to modifiers using the toModifier function which takes the AttributeMapping as input. Afterwards the Modifiers are treated the same as the existing Modifiers. Added new Modifiers for RangeCriterion and NumericCriterion.