### PR TITLE
Ignore Empty Concept AttributeFilter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.35</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-jupiter.version}</version>

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/Criterion.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/Criterion.java
@@ -12,6 +12,7 @@ import de.numcodex.sq2cql.model.cql.BooleanExpression;
 import de.numcodex.sq2cql.model.cql.CodeSystemDefinition;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import static java.util.Objects.requireNonNull;
@@ -43,6 +44,7 @@ public interface Criterion {
 
         var attributes = (attributeFilters == null ? List.<ObjectNode>of() : attributeFilters).stream()
                 .map(AttributeFilter::fromJsonNode)
+                .flatMap(Optional::stream)
                 .toArray(AttributeFilter[]::new);
 
         if (valueFilter == null) {
@@ -72,8 +74,8 @@ public interface Criterion {
         }
         if ("concept".equals(type)) {
             var selectedConcepts = valueFilter.get("selectedConcepts");
-            if (selectedConcepts == null) {
-                throw new IllegalArgumentException("Missing `selectedConcepts` key in concept criterion.");
+            if (selectedConcepts == null || selectedConcepts.isEmpty()) {
+                throw new IllegalArgumentException("Missing or empty `selectedConcepts` key in concept criterion.");
             }
             return ValueSetCriterion.of(concept, StreamSupport.stream(selectedConcepts.spliterator(), false)
                     .map(TermCode::fromJsonNode).toList(), attributes);

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/ValueSetAttributeFilter.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/ValueSetAttributeFilter.java
@@ -21,6 +21,8 @@ public record ValueSetAttributeFilter(TermCode attributeCode, List<TermCode> sel
      * @param attributeCode    the code identifying the attribute
      * @param selectedConcepts at least one selected value concept
      * @return the {@code ValueSetCriterion}
+     * @throws IllegalArgumentException if {@code selectedConcepts} are empty
+     * @throws NullPointerException     if any of the {@code selectedConcepts} is null
      */
     public static ValueSetAttributeFilter of(TermCode attributeCode, TermCode... selectedConcepts) {
         if (selectedConcepts == null || selectedConcepts.length == 0) {

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ValueSetAttributeFilterTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ValueSetAttributeFilterTest.java
@@ -1,0 +1,19 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.model.common.TermCode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ValueSetAttributeFilterTest {
+
+    private static final TermCode CODE = TermCode.of("foo", "bar", "baz");
+
+    @Test
+    void of_WithoutSelectedConcepts() {
+        var error = assertThrows(IllegalArgumentException.class, () -> ValueSetAttributeFilter.of(CODE));
+
+        assertEquals("empty selected concepts", error.getMessage());
+    }
+}


### PR DESCRIPTION
Attribute filters with empty selected concepts are ignored because they essentially do not filter anything. Although the JSON schema disallows missing selectedConcept keys or empty arrays, it's more robust to not fail in such a case. Nevertheless, we log a warning here.